### PR TITLE
Removed CentOS 6 incompatible options from the sshd_config template

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -44,7 +44,11 @@ AuthorizedKeysFile	{{ sshd_authorized_keys_file }}
 AuthorizedPrincipalsFile {{ sshd_authorized_principals_file }}
 
 AuthorizedKeysCommand {{ sshd_authorized_keys_command }}
+{% if ansible_distribution == 'CentOS' %}
+AuthorizedKeysCommandRunAs {{ sshd_authorized_keys_command_user }}
+{% else %}
 AuthorizedKeysCommandUser {{ sshd_authorized_keys_command_user }}
+{% endif %}
 
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
 RhostsRSAAuthentication {{ sshd_rhosts_rsa_authentication }}
@@ -102,7 +106,9 @@ PidFile {{ sshd_pid_file }}
 MaxStartups {{ sshd_max_startups }}
 PermitTunnel {{ sshd_permit_tunnel }}
 ChrootDirectory {{ sshd_chroot_directory }}
+{% if ansible_distribution != 'CentOS' %}
 VersionAddendum {{ sshd_version_addendum }}
+{% endif %}
 
 # no default banner path
 Banner {{ sshd_banner }}


### PR DESCRIPTION
'AuthorizedKeysCommandRunAs' is the equivalent of the 'AuthorizedKeysCommandUser' option in the version of OpenSSH that ships with CentOS 6.5

'VersionAddendum' is not a valid option so sshd fails if it's included.

The following are error messages reported without these changes:

```
NOTIFIED: [generic/sshd | restart sshd] ***************************************
failed: [config] => {"failed": true, "item": ""}
msg: /etc/ssh/sshd_config: line 47: Bad configuration option: AuthorizedKeysCommandUser

NOTIFIED: [generic/sshd | restart sshd] ***************************************
failed: [config] => {"failed": true, "item": ""}
msg: /etc/ssh/sshd_config: line 105: Bad configuration option: VersionAddendum
/etc/ssh/sshd_config: terminating, 1 bad configuration options
```
